### PR TITLE
Adjusted logic to show empty cart text

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -2,13 +2,13 @@ import { getLocalStorage, setLocalStorage, setClick } from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
-  if (cartItems.length > 0) {
+  if (!cartItems || cartItems.length === 0) {
+    document.querySelector(".product-list").innerHTML =
+      "Your cart is currently empty";
+  } else if (cartItems.length > 0) {
     const htmlItems = cartItems.map((item) => cartItemTemplate(item));
     document.querySelector(".product-list").innerHTML = htmlItems.join("");
     setClick(".cart-card__remove-btn", removeFromCart);
-  } else {
-    document.querySelector(".product-list").innerHTML =
-      "Your cart is currently empty";
   }
 }
 


### PR DESCRIPTION
Adjusted the logic to account for the cases when the cart has never had anything in to so the LocalStorage object `so-cart` does not exist to have it's length checked.